### PR TITLE
fix: adjust elixir ver to 1.11.0 to adjust for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         otp: ['22.2.8']
-        elixir: ['1.10.3']
+        elixir: ['1.11.0']
 
     services:
       db:


### PR DESCRIPTION
This PR addresses an issue where `postgrex` function requires a newer Elixir version, where we are using an outdated version in CI Workflow.